### PR TITLE
Use `files` field of package.json and delete .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,8 +1,0 @@
-# same with .gitignore
-node_modules
-test.db*
-package-lock.json
-
-src
-build
-test

--- a/package.json
+++ b/package.json
@@ -13,6 +13,10 @@
         "database",
         "fibjs"
     ],
+    "files": [
+        "@types",
+        "lib"
+    ],
     "scripts": {
         "ci": "fibjs test",
         "bundle": "fibjs ./build/bundle"


### PR DESCRIPTION
Using files to **include** the correct files in the package, instead of excluding them.

This way, for example, `.travis.yml` isn't included in the published npm package.